### PR TITLE
lighter background color for bookify; rename it

### DIFF
--- a/index.xhtml
+++ b/index.xhtml
@@ -106,15 +106,15 @@
           );
           document.head.insertAdjacentHTML('beforeend',
             '&lt;style&gt;
-              html { background: grey; }
+              html { background: #ddd; }
               body {
                  background: linear-gradient( to right, #f9f9f9, #fff 10%, #fff 90%, #f9f9f9 100% );
                  filter: sepia(3%) saturate(85%) contrast(98%); text-align: justify;
-                 max-width: 40em; padding: 1em 5em; margin: 10px auto; border-radius: 2px; box-shadow: 0 0 10px -1px;
+                 max-width: 40em; padding: 1em 5em; margin: 10px auto; border-radius: 3px; box-shadow: 0 0 7px -3px;
               }
               h1, h2, h3, h4, h5, h6 { text-align: initial; }
             &lt;/style&gt;'
-          )">bookify</a>
+          )">paperlike</a>
       </strong>
     </p>
     <p>✻</p>


### PR DESCRIPTION
Fixes #41. Also changes the label in the bookmarklet from "bookify" to "paperlike", which is more accurate after c7fa814, and more intuitive anyway.